### PR TITLE
Build error fixes

### DIFF
--- a/frontend/package.tmpl.json
+++ b/frontend/package.tmpl.json
@@ -13,6 +13,7 @@
     "postcss": "^8.4.5",
     "svelte": "^3.44.0",
     "tailwindcss": "^3.0.12",
-    "vite": "^2.7.2"
-  }
-,"author":"{{.AuthorName}}"}
+    "vite": "^3.0.0"
+  },
+  "author":"{{.AuthorName}}"
+}

--- a/main.tmpl.go
+++ b/main.tmpl.go
@@ -31,7 +31,7 @@ func main() {
 		Frameless:         false,
 		StartHidden:       false,
 		HideWindowOnClose: false,
-		RGBA:              &options.RGBA{255, 255, 255, 255},
+		BackgroundColour:  &options.RGBA{255, 255, 255, 255},
 		Assets:            assets,
 		LogLevel:          logger.DEBUG,
 		OnStartup:         app.startup,


### PR DESCRIPTION
Fixes #4 and enables out-of-the-box building:
- Vite 3 bump
- Renamed the missing field in Go app template (see original [`svelte-ts`](https://github.com/wailsapp/wails/blob/1644ee152ecf0fc79600413642ba624077b8de4d/v2/pkg/templates/templates/svelte-ts/main.go.tmpl#L26) template)